### PR TITLE
Fix mistake in dir2cast.ini example for ITUNES_EXPLICIT

### DIFF
--- a/dir2cast.ini
+++ b/dir2cast.ini
@@ -99,8 +99,10 @@
 
 ; Whether or not the feed contains explicit content.
 ; See https://github.com/simplepie/simplepie-ng/wiki/Spec:-iTunes-Podcast-RSS
-; Valid values are yes, explicit, true or no, clean, false
-;ITUNES_EXPLICIT = false
+; Valid values are "yes", "explicit", "true" or "no", "clean", "false"
+;
+; If you don't set this, it will not appear in the feed at all! 
+;ITUNES_EXPLICIT = "no"
 
 
 ; *** INFORMATION ABOUT YOUR PODCAST - the following can be set using text files ***

--- a/dir2cast.php
+++ b/dir2cast.php
@@ -1603,7 +1603,7 @@ class SettingsHandler
             define('ITUNES_CATEGORIES', '');
         
         if(!defined('ITUNES_EXPLICIT'))
-            define('ITUNES_EXPLICIT', 'false');
+            define('ITUNES_EXPLICIT', '');
             
         if(!defined('LONG_TITLES'))
             define('LONG_TITLES', false);


### PR DESCRIPTION
ini handling treats yes, true, no and false as booleans.