### PR TITLE
Feature/respect changes other than most recently modified

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,11 @@ Changelog
 =========
 
 1.33 unreleased * README fixed by @denilsonsa - thanks!
+                * Caching algorithm changed to so that it is no longer dependent
+                  on added media files having a newer file date (GitHub #51),
+                  and will look for any changes in filesize or date, as well
+                  as addition or removal of files. This means that dir2cast is
+                  now much more friendly to use cases for local media collections.
 
 1.32 2022-04-18 * Upgrade getID3 (includes important security fix for PHP 8+)
 

--- a/test/CachingTest.php
+++ b/test/CachingTest.php
@@ -43,7 +43,7 @@ class CachingTest extends TestCase
         clearstatcache();
         $cached_mtime_before = filemtime($cached_output_files[0]);
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime', $new_output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime --clock-offset=7', $new_output, $this->returncode);
 
         clearstatcache();
         $cached_output_files = glob(temp_xml_glob());
@@ -71,7 +71,7 @@ class CachingTest extends TestCase
         clearstatcache();
         $cached_mtime_before = filemtime($cached_output_files[0]);
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime', $new_output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime --clock-offset=7', $new_output, $this->returncode);
 
         clearstatcache();
         $cached_output_files = glob(temp_xml_glob());
@@ -104,7 +104,7 @@ class CachingTest extends TestCase
         clearstatcache();
         $cached_mtime_before = filemtime($cached_output_files[0]);
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime', $new_output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime --clock-offset=7', $new_output, $this->returncode);
 
         clearstatcache();
         $cached_output_files = glob(temp_xml_glob());
@@ -138,7 +138,7 @@ class CachingTest extends TestCase
         clearstatcache();
         $cached_mtime_before = filemtime($cached_output_files[0]);
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime', $new_output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --ignore-dir2cast-mtime --clock-offset=90', $new_output, $this->returncode);
 
         clearstatcache();
         $cached_output_files = glob(temp_xml_glob());
@@ -168,7 +168,7 @@ class CachingTest extends TestCase
 
         // --dont-uncache: tells dir2cast not use the default caching rules, not ignore them due to CLI
         // --min-file-age=0 : tells dir2cast to include files that are brand new
-        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=0 --ignore-dir2cast-mtime', $this->output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=0 --ignore-dir2cast-mtime --clock-offset=2', $this->output, $this->returncode);
 
         $new_content = file_get_contents($this->file);
         $this->assertEquals($this->content, $new_content);
@@ -184,7 +184,7 @@ class CachingTest extends TestCase
 
         // --dont-uncache: tells dir2cast not use the default caching rules, not ignore them due to CLI
         // --min-file-age=0 : tells dir2cast to include files that are brand new
-        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=0 --ignore-dir2cast-mtime', $this->output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=0 --ignore-dir2cast-mtime --clock-offset=3600', $this->output, $this->returncode);
 
         $new_content = file_get_contents($this->file);
         $this->assertNotEquals($this->content, $new_content);
@@ -198,7 +198,7 @@ class CachingTest extends TestCase
         // too new to bust the cache, but cli runner uncaches anyway
         file_put_contents('empty.mp3', 'test');
 
-        exec('php dir2cast.php --output=out.xml --min-file-age=0 --ignore-dir2cast-mtime', $this->output, $this->returncode);
+        exec('php dir2cast.php --output=out.xml --min-file-age=0 --ignore-dir2cast-mtime --clock-offset=2', $this->output, $this->returncode);
 
         $new_content = file_get_contents($this->file);
         $this->assertNotEquals($this->content, $new_content);
@@ -217,7 +217,7 @@ class CachingTest extends TestCase
         file_put_contents('empty.mp3', 'test');
         touch('empty.mp3', time()-3600); // busts cache as older than min-file-age
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=30 --ignore-dir2cast-mtime');
+        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=30 --ignore-dir2cast-mtime --clock-offset=86400');
         $new_content = file_get_contents($this->file); // should have empty.mp3
         $this->assertNotEquals($this->content, $new_content);
         $this->assertEquals(1, preg_match('/empty\.mp3/', $new_content));
@@ -246,7 +246,7 @@ class CachingTest extends TestCase
         // (which it shouldn't be!)
         sleep(1);
 
-        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=30 --ignore-dir2cast-mtime');
+        exec('php dir2cast.php --output=out.xml --dont-uncache --min-file-age=30 --ignore-dir2cast-mtime --clock-offset=86400');
 
         $new_content = file_get_contents($this->file); // should not have empty.mp3
 

--- a/test/Dir_PodcastTest.php
+++ b/test/Dir_PodcastTest.php
@@ -17,6 +17,7 @@ class Dir_PodcastTest extends PodcastTest
         parent::setUp();
         Dir_Podcast::$RECURSIVE_DIRECTORY_ITERATOR = false;
         Dir_Podcast::$ITEM_COUNT = 10;
+        Dir_Podcast::$DEBUG = false;
     }
 
     public function newPodcast()
@@ -110,7 +111,6 @@ class Dir_PodcastTest extends PodcastTest
 
     public function test_regenerates_if_metadata_files_added()
     {
-        Dir_Podcast::$DEBUG = false;
         Media_RSS_Item::$DESCRIPTION_SOURCE = 'summary';
         $filemtime = $this->createTestItems();
         age_dir_by('.', 200);
@@ -204,7 +204,6 @@ class Dir_PodcastTest extends PodcastTest
 
     public function tearDown(): void
     {
-        Dir_Podcast::$DEBUG = false;
         Media_RSS_Item::$DESCRIPTION_SOURCE = 'comment';
         $this->delete_test_files();
         parent::tearDown();

--- a/test/Dir_Podcast_RecursiveTest.php
+++ b/test/Dir_Podcast_RecursiveTest.php
@@ -78,7 +78,6 @@ class Dir_Podcast_RecursiveTest extends Dir_PodcastTest
 
     public function test_regenerates_if_metadata_files_added()
     {
-        Dir_Podcast::$DEBUG = false;
         Media_RSS_Item::$DESCRIPTION_SOURCE = 'summary';
         $filemtime = $this->createTestItems();
         age_dir_by('.', 200);

--- a/test/Locking_Cached_Dir_PodcastTest.php
+++ b/test/Locking_Cached_Dir_PodcastTest.php
@@ -10,9 +10,10 @@ class Locking_Cached_Dir_PodcastTest extends Cached_Dir_PodcastTest
         Cached_Dir_PodcastTest::setUpBeforeClass();
     }
 
-    public function newPodcast()
+    public function newPodcast($offset=0)
     {
         $podcast = new Locking_Cached_Dir_Podcast('.', './temp');
+        $podcast->setClockOffset($offset);
         $podcast->init();
         return $podcast;
     }


### PR DESCRIPTION
This patch will refresh the cache if the content of the podcast folder changes in a meaningful way - that is, if the number of media files changes, or the size or date of any media file, or the size or date of any of the related files (cover art etc)

intended to address #51 