### PR TITLE
add docker notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Features:
 * You can set a per-file iTunes Summary by creating a text file with the same
   name as the media file (e.g. for file.mp3, create file.txt).
 
+* You can deploy a container the babyraptor/dir2cast Docker image
+
 
 QUICK HOW TO GUIDES
 ================================================================================
@@ -96,6 +98,25 @@ podcast that it generates uses the tags from your files.
    The generated feed is cached. It will regenerate if you add a new media
    file, but if you want to force a regeneration delete the files from 
    the "`temp`" folder that is created.
+
+
+DOCKER SETUP
+================================================================================
+Note: I did not create the image that I've deployed (project is in the works there), so this is a product of trial and error. Similarly, I do not use docker-compose but the "create container" tool in portainer so keep in mind these are more a guide than an exact recipe.
+
+Local setup
+1. Make sure to pull the image, even with the weird tag babyraptor/dir2cast:69adefa
+2. Map the container's port 80 to whatever port you want to access it with on your local network
+3. Create a volume to map with /var/www/html
+4. If desired, you can bind the /var/www/html/<episode folder> to a location on some shared drive that you drop files into from your PC instead of in a docker volume
+5. Your podcast feed should now exist at <docker ip>:<container port>/dir2cast.php
+
+
+Remote w SWAG
+1. Install SWAG and test that you can remotely access your docker server https://docs.linuxserver.io/general/swag
+2. Create a <name>.subdomain.conf file for your podcast server container (again, linuxserver) with the container name and internal port (not the port you use locally to hit the host)
+3. Add your dir2cast container to the network that you created with SWAG
+4. Check that podcasts can be played/downloaded. If your feed is exists but files aren't available, update MP3_URL in the dir2cast.ini file for https (see comment in that file)
 
 
 UNDERSTANDING HOW THE CACHING WORKS

--- a/README.md
+++ b/README.md
@@ -102,22 +102,25 @@ podcast that it generates uses the tags from your files.
 
 DOCKER SETUP
 ================================================================================
-Note: I did not create the image that I've deployed (project is in the works there), so this is a product of trial and error. Similarly, I do not use docker-compose but the "create container" tool in portainer so keep in mind these are more a guide than an exact recipe.
+Note: I did not create the image that I've deployed (project is in the works there), so this is a product of trial and error. There are settings in dir2cast or swag that are not covered in this 
 
 Local setup
 1. Make sure to pull the image, even with the weird tag babyraptor/dir2cast:69adefa
-2. Map the container's port 80 to whatever port you want to access it with on your local network
+2. Map the container's port 80 to whatever port you want to access it with on your local network (i.e. port 8080)
 3. Create a volume to map with /var/www/html
 4. If desired, you can bind the /var/www/html/<episode folder> to a location on some shared drive that you drop files into from your PC instead of in a docker volume
-5. Your podcast feed should now exist at <docker ip>:<container port>/dir2cast.php
-
+5. Combine these into something like `docker run --name dir2cast -d -p 8080:80 -v podcast_volume:/var/www/html babyraptor/dir2cast:69adefa`
+6. Once you add mp3 files, your podcast feed should now exist at <docker server ip>:<container port>/dir2cast.php
 
 Remote w SWAG
-1. Install SWAG and test that you can remotely access your docker server https://docs.linuxserver.io/general/swag
-2. Create a <name>.subdomain.conf file for your podcast server container (again, linuxserver) with the container name and internal port (not the port you use locally to hit the host)
+1. Install SWAG and test that you can remotely access your docker server. Here's a guide https://docs.linuxserver.io/general/swag
+2. Create a <name>.subdomain.conf file for your podcast server container as specified in the swag guide
 3. Add your dir2cast container to the network that you created with SWAG
-4. Check that podcasts can be played/downloaded. If your feed is exists but files aren't available, update MP3_URL in the dir2cast.ini file for https (see comment in that file)
+4. Check that podcasts can be played/downloaded. If your feed exists and can be subscribed to, but files aren't available, update MP3_URL in the dir2cast.ini file for https (see comment in that file)
 
+Notes
+* if you have shared folders that are accessible from your PC, a bind mount can make it easier to drag and drop. if you see '.\_' prefixed junk files in your feed, that is a mac issue (not dir2cast)
+* 502 errors are likely swag configuration problems. Check container name, port mapping, etc
 
 UNDERSTANDING HOW THE CACHING WORKS
 ================================================================================

--- a/dir2cast.ini
+++ b/dir2cast.ini
@@ -45,6 +45,8 @@
 ; This defaults to the directory of the script.
 ; dir2cast can usually work this out for you, but under some circumstances
 ; it will fail. If your MP3 URLs are all wrong, try putting this in manually.
+; If the xml/rss feed exists but podcasts won't play/download, you may need
+; to set this with https i.e. "https://www.example.foo/my_mp3_folder/"
 ;MP3_URL = "http://www.example.foo/my_mp3_folder/"
 
 ; Uncomment this if you want to check in every sub-folder for new files as well.


### PR DESCRIPTION
added notes for docker deploy using the babyraptor/dir2cast image. I recently set this up locally and am documenting my trial and error into a more formalized guide before I go about building a more open container around dir2cast. not sure if this is worthy of a changelog entry