### PR TITLE
Add ability to set Title of podcast using title.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Features:
 * iTunes 'image' supported: just drop a file called itunes_image.jpg in the same
   folder as your media files.
 
-* RSS Description, iTunes Subtitle and iTunes Summary can be set by dropping
-  files named description.txt, itunes_subtitle.txt and itunes_summary.txt 
+* RSS Title, Description, iTunes Subtitle and iTunes Summary can be set by dropping
+  files named title.txt, description.txt, itunes_subtitle.txt and itunes_summary.txt 
   in the same folder as dir2cast.php - but they are not required. (You can
   also set these in the config).
 

--- a/dir2cast.php
+++ b/dir2cast.php
@@ -1881,7 +1881,9 @@ class SettingsHandler
 
         if(!defined('TITLE'))
         {
-            if(basename(MP3_DIR()))
+            if(file_exists(MP3_DIR() . 'title.txt'))
+                define('TITLE', file_get_contents(MP3_DIR() . 'title.txt'));
+            elseif(basename(MP3_DIR()))
                 define('TITLE', basename(MP3_DIR()));
             else
                 define('TITLE', 'My First dir2cast Podcast');
@@ -2115,6 +2117,7 @@ class Dispatcher
         // Ensure that the cache is invalidated if we have updated any of non-episode files used for feed metadata
         $metadata_files = array(
             'description.txt',
+            'title.txt',
             'itunes_summary.txt',
             'itunes_subtitle.txt',
             'image.jpg',


### PR DESCRIPTION
Adding the ability to add a title.txt to the MP3 folder would set the title of the podcast. Adding this since I have some podcasts with spaces in the title, but when trying to load the iTunes image, this wouldn't always play nice.

**Previous**
Folder: `/localdir/some podcast with spaces/`
URL podcast: `www.base-url.com/some%20podcast%20with%spaces`
Itunes image:  `www.base-url.com/some%20podcast%20with%spaces/itunes_image.jpg`

**Current**
Folder: `/localdir/somepodcastwithoutspaces/`
Title.txt: `Some podcast with spaces`
URL podcast: `www.base-url.com/somepodcastwithoutspaces`
Itunes image: ` www.base-url.com/somepodcastwithoutspaces/itunes_image.jpg`
