### PR TITLE
feat: added `itunes:block` channel tag option

### DIFF
--- a/dir2cast.ini
+++ b/dir2cast.ini
@@ -105,6 +105,14 @@
 ; Podcasts may reject your feed!
 ;ITUNES_EXPLICIT = "no"
 
+; Whether or not to include the podcast in the iTunes podcast directory.
+; See https://github.com/simplepie/simplepie-ng/wiki/Spec:-iTunes-Podcast-RSS
+; Valid values are "Yes" or "yes". Any other value will be ignored.
+;
+; Only set this if you want the feed to be private and completely excluded from 
+; any podcast directory scanning.
+;ITUNES_BLOCK = "no"
+
 
 ; *** INFORMATION ABOUT YOUR PODCAST - the following can be set using text files ***
 

--- a/dir2cast.php
+++ b/dir2cast.php
@@ -390,6 +390,11 @@ class iTunes_Podcast_Helper extends GetterSetter implements Podcast_Helper {
                 ->appendChild( new DOMText( $this->explicit ) );
         }
         
+        if(!empty($this->block))
+        {
+            $channel->appendChild( $doc->createElement('itunes:block') )
+                ->appendChild( new DOMText( $this->block ) );
+        }
         
         if(!empty($this->image_href))
         {
@@ -532,6 +537,11 @@ class iTunes_Podcast_Helper extends GetterSetter implements Podcast_Helper {
     public function setExplicit($explicit)
     {
         $this->explicit = $explicit;
+    }
+    
+    public function setBlock($block)
+    {
+        $this->block = $block;
     }
 }
 
@@ -1999,6 +2009,9 @@ class SettingsHandler
         if(!defined('ITUNES_EXPLICIT'))
             define('ITUNES_EXPLICIT', '');
             
+        if(!defined('ITUNES_BLOCK'))
+            define('ITUNES_BLOCK', '');
+            
         if(!defined('LONG_TITLES'))
             define('LONG_TITLES', false);
 
@@ -2166,6 +2179,7 @@ class Dispatcher
             $itunes->setSummary(ITUNES_SUMMARY);
             $itunes->setImage(ITUNES_IMAGE);
             $itunes->setExplicit(ITUNES_EXPLICIT);
+            $itunes->setBlock(ITUNES_BLOCK);
 
             $itunes->setOwnerName(ITUNES_OWNER_NAME);
             $itunes->setOwnerEmail(ITUNES_OWNER_EMAIL);

--- a/test/SettingsHandlerTest.php
+++ b/test/SettingsHandlerTest.php
@@ -34,6 +34,7 @@ class SettingsHandlerTest extends TestCase
         'ITUNES_AUTHOR',
         'ITUNES_CATEGORIES',
         'ITUNES_EXPLICIT',
+        'ITUNES_BLOCK',
         'LONG_TITLES',
         'ITUNES_SUBTITLE_SUFFIX',
         'ITUNES_TYPE',
@@ -510,6 +511,7 @@ class SettingsHandlerTest extends TestCase
         $this->assertEquals(ITUNES_AUTHOR, '');
         $this->assertEquals(ITUNES_CATEGORIES, '');
         $this->assertEquals(ITUNES_EXPLICIT, '');
+        $this->assertEquals(ITUNES_BLOCK, '');
         $this->assertEquals(LONG_TITLES, false);
         $this->assertEquals(ITUNES_SUBTITLE_SUFFIX, '');
         $this->assertEquals(ITUNES_TYPE, 'episodic');

--- a/test/iTunes_Podcast_HelperTest.php
+++ b/test/iTunes_Podcast_HelperTest.php
@@ -143,6 +143,17 @@ final class iTunes_Podcast_HelperTest extends TestCase
         $this->assertChannelHasElement('explicit', 'yes', $data->channel);
     }
 
+    public function test_adds_block_to_podcast()
+    {
+        $mp = new MyPodcast();
+        $itunes = $mp->addHelper(new iTunes_Podcast_Helper());
+        $itunes->setBlock('yes');
+        $content = $mp->generate();
+
+        $data = simplexml_load_string($content, 'SimpleXMLElement');
+        $this->assertChannelHasElement('block', 'yes', $data->channel);
+    }
+
     public function test_adds_image_to_podcast()
     {
         $mp = new MyPodcast();


### PR DESCRIPTION
This can be used to explicity mark the podcast as not for public use. It is recommended for private podcasts by https://overcast.fm/podcasterinfo